### PR TITLE
feat: centralize env configuration

### DIFF
--- a/src/app/api/documents/[documentId]/route.ts
+++ b/src/app/api/documents/[documentId]/route.ts
@@ -4,8 +4,9 @@ import docClient, { MAIN_TABLE_NAME } from '@/lib/aws/dynamodb';
 import { GetCommand, DeleteCommand } from '@aws-sdk/lib-dynamodb';
 import { s3Client } from '@/lib/aws/s3';
 import { ListObjectsV2Command, DeleteObjectsCommand } from '@aws-sdk/client-s3';
+import { config } from '@/lib/config';
 
-const BUCKET = process.env.S3_BUCKET_NAME as string | undefined;
+const BUCKET = config.s3BucketName;
 
 // Type guard for DynamoDB document item ownership
 function isOwnedByUser(item: unknown, userId: string): item is { userId: string } {
@@ -81,9 +82,6 @@ export async function DELETE(
     if (!isOwnedByUser(getRes.Item, userId)) {
       return NextResponse.json({ message: '문서를 삭제할 권한이 없습니다.' }, { status: 403 });
     }
-
-    if (!BUCKET)
-      return NextResponse.json({ message: 'S3_BUCKET_NAME이 설정되지 않았습니다.' }, { status: 500 });
 
     const prefix = `uploads/${userId}/${documentId}/`;
     await deleteS3Prefix(BUCKET, prefix);

--- a/src/app/api/documents/[documentId]/summarize/route.ts
+++ b/src/app/api/documents/[documentId]/summarize/route.ts
@@ -8,8 +8,9 @@ import { GoogleGenerativeAI, GenerationConfig } from '@google/generative-ai';
 import { extractTextFromBuffer, streamToBuffer } from '@/lib/documents/text-extract';
 import type { DocumentItem } from '@/types/document';
 import { enqueueSummarizeJob } from '@/lib/documents/queue';
+import { config } from '@/lib/config';
 
-const BUCKET = process.env.S3_BUCKET_NAME || '';
+const BUCKET = config.s3BucketName;
 const SUMMARIZE_MODEL = process.env.SUMMARIZE_MODEL || 'gemini-1.5-flash';
 const SUMMARIZE_TIMEOUT_MS = Number(process.env.SUMMARIZE_TIMEOUT_MS || 45000);
 const SUMMARIZE_MAX_CHARS = Number(process.env.SUMMARIZE_MAX_CHARS || 20000);
@@ -70,9 +71,7 @@ async function getObjectText(bucket: string, key: string): Promise<{ text: strin
 }
 
 async function summarizeText(text: string): Promise<string> {
-  const apiKey = process.env.GEMINI_API_KEY || '';
-  if (!apiKey) throw new Error('GEMINI_API_KEY is not configured');
-  const genAI = new GoogleGenerativeAI(apiKey);
+  const genAI = new GoogleGenerativeAI(config.geminiApiKey);
   const model = genAI.getGenerativeModel({ model: SUMMARIZE_MODEL });
   const promptTemplate = process.env.SUMMARIZE_PROMPT_TEMPLATE || `아래 문서 내용을 한국어로 간결하게 요약해 주세요.
 ---
@@ -111,10 +110,6 @@ export async function POST(
     if (!auth.ok) return auth.res;
     const userId = auth.userId;
     const documentId = params.documentId;
-
-    if (!BUCKET) {
-      return NextResponse.json({ message: 'S3_BUCKET_NAME이 설정되지 않았습니다.' }, { status: 500 });
-    }
 
     const doc = await loadDocument(userId, documentId);
     if (!doc) return NextResponse.json({ message: '문서를 찾을 수 없거나 권한이 없습니다.' }, { status: 404 });

--- a/src/app/api/documents/presign/route.ts
+++ b/src/app/api/documents/presign/route.ts
@@ -3,11 +3,12 @@ import { requireAuth } from '@/lib/api/auth';
 import { v4 as uuidv4 } from 'uuid';
 import { S3Client, S3ClientConfig } from '@aws-sdk/client-s3';
 import { createPresignedPost } from '@aws-sdk/s3-presigned-post';
+import { config } from '@/lib/config';
 
-const BUCKET = process.env.S3_BUCKET_NAME;
-const REGION = process.env.AWS_REGION || 'ap-northeast-2';
-const PUBLIC_ENDPOINT = process.env.S3_PUBLIC_ENDPOINT; // e.g., http://localhost:4566 for LocalStack (browser-accessible)
-const IS_DEV = process.env.NODE_ENV === 'development';
+const BUCKET = config.s3BucketName;
+const REGION = config.awsRegion;
+const PUBLIC_ENDPOINT = config.s3PublicEndpoint; // e.g., http://localhost:4566 for LocalStack (browser-accessible)
+const IS_DEV = config.nodeEnv === 'development';
 
 const MAX_UPLOAD_SIZE_MB = Number(process.env.MAX_UPLOAD_SIZE_MB || 25);
 const MAX_BYTES = MAX_UPLOAD_SIZE_MB * 1024 * 1024;
@@ -24,10 +25,10 @@ const ALLOWED_TYPES = [
 function buildPresignClient() {
   // In development, prefer PUBLIC endpoint so the browser can use the URL directly (e.g., localhost:4566)
   // In other environments, default to internal endpoint if provided, otherwise AWS default resolution
-  const endpoint = IS_DEV ? (PUBLIC_ENDPOINT || process.env.S3_ENDPOINT) : process.env.S3_ENDPOINT;
+  const endpoint = IS_DEV ? (PUBLIC_ENDPOINT || config.s3Endpoint) : config.s3Endpoint;
   const credentials = {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'dummy',
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'dummy',
+    accessKeyId: config.awsAccessKeyId || 'dummy',
+    secretAccessKey: config.awsSecretAccessKey || 'dummy',
   };
   const cfg: S3ClientConfig = { region: REGION, credentials };
   if (endpoint) (cfg as any).endpoint = endpoint;
@@ -50,10 +51,6 @@ export async function POST(req: NextRequest) {
     const auth = requireAuth(req);
     if (!auth.ok) return auth.res;
     const userId = auth.userId;
-
-    if (!BUCKET) {
-      return NextResponse.json({ message: 'S3_BUCKET_NAME 환경 변수가 설정되지 않았습니다.' }, { status: 500 });
-    }
 
     const body = await req.json().catch(() => null);
     const filename = body?.filename as string | undefined;

--- a/src/app/api/documents/route.ts
+++ b/src/app/api/documents/route.ts
@@ -6,8 +6,9 @@ import type { DocumentItem, DocumentStatus } from '@/types/document';
 import { s3Client } from '@/lib/aws/s3';
 import { PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { config } from '@/lib/config';
 
-const S3_BUCKET_NAME = process.env.S3_BUCKET_NAME;
+const S3_BUCKET_NAME = config.s3BucketName;
 
 export async function POST(req: NextRequest) {
   try {
@@ -64,10 +65,6 @@ export async function POST(req: NextRequest) {
     if (!file) {
       return NextResponse.json({ message: '파일이 필요합니다.' }, { status: 400 });
     }
-    if (!S3_BUCKET_NAME) {
-      return NextResponse.json({ message: 'S3_BUCKET_NAME 환경 변수가 설정되지 않았습니다.' }, { status: 500 });
-    }
-
     const documentId = uuidv4();
     const fileBuffer = Buffer.from(await file.arrayBuffer());
     const s3Key = `uploads/${userId}/${documentId}/${file.name}`;

--- a/src/app/api/study/analyze/route.ts
+++ b/src/app/api/study/analyze/route.ts
@@ -13,10 +13,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/api/auth';
 import { GoogleGenerativeAI } from "@google/generative-ai";
+import { config } from '@/lib/config';
 
 // --- AI 모델 초기화 ---
 // [클린 코드] AI 모델 클라이언트를 전역 상수로 초기화하여 재사용하고, API 키는 환경 변수에서 안전하게 관리합니다.
-const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || "");
+const genAI = new GoogleGenerativeAI(config.geminiApiKey);
 
 /**
  * @function callAiModel

--- a/src/app/api/study/quiz/route.ts
+++ b/src/app/api/study/quiz/route.ts
@@ -12,16 +12,12 @@
 
 import { NextResponse } from 'next/server';
 import { GoogleGenerativeAI, SchemaType, GenerationConfig } from '@google/generative-ai';
-
-// --- 환경 변수 관리 ---
-// [클린 코드] 환경 변수는 한 곳에서 관리하며, 값이 없을 경우를 대비해 기본값을 설정합니다.
-// process.env는 서버 사이드에서만 접근 가능하므로 API 키를 안전하게 보호할 수 있습니다.
-const GEMINI_API_KEY = process.env.GEMINI_API_KEY || "";
+import { config } from '@/lib/config';
 
 // --- Google Generative AI 클라이언트 초기화 ---
 // [React 개념: 서버 사이드 렌더링(SSR) 및 API 라우트]
 // Next.js의 API 라우트는 서버에서 실행되므로, 외부 API(Gemini)와의 통신을 안전하게 처리할 수 있습니다.
-const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
+const genAI = new GoogleGenerativeAI(config.geminiApiKey);
 
 /**
  * AI 퀴즈 생성 POST 요청 핸들러

--- a/src/app/api/study/search/route.ts
+++ b/src/app/api/study/search/route.ts
@@ -15,10 +15,11 @@ import { requireAuth } from '@/lib/api/auth';
 import docClient, { STUDY_TABLE_NAME } from '@/lib/aws/dynamodb';
 import { QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { GoogleGenerativeAI } from "@google/generative-ai";
+import { config } from '@/lib/config';
 
 // --- AI 모델 초기화 ---
 // [클린 코드] AI 모델 클라이언트를 전역 상수로 초기화하여 재사용하고, API 키는 환경 변수에서 안전하게 관리합니다.
-const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || "");
+const genAI = new GoogleGenerativeAI(config.geminiApiKey);
 
 /**
  * @function callAiSearchModel

--- a/src/lib/auth/password.ts
+++ b/src/lib/auth/password.ts
@@ -1,7 +1,9 @@
 import bcrypt from "bcryptjs";
+import { config } from '@/lib/config';
 
 export const hashPassword = async (password: string): Promise<string> => {
-    const hashedPassword = await bcrypt.hash(password, process.env.HASH_SALT || 10);
+    const salt = Number(config.hashSalt) || 10;
+    const hashedPassword = await bcrypt.hash(password, salt);
     return hashedPassword;
 }
 

--- a/src/lib/auth/token.ts
+++ b/src/lib/auth/token.ts
@@ -1,44 +1,29 @@
 import jwt from 'jsonwebtoken';
+import { config } from '@/lib/config';
 
 type SignOpts = {
   expiresIn?: string | number;
 };
+
+const secret = config.jwtSecret;
 
 export const generateAccessToken = (
   userId: string,
   email: string,
   opts: SignOpts = { expiresIn: '1h' }
 ): string => {
-  const secret = process.env.JWT_SECRET;
-
-  if (!secret) {
-    throw new Error('JWT_SECRET is not defined in environment variables.');
-  }
-
   const payload = { userId, email };
   const token = jwt.sign(payload, secret, { expiresIn: opts.expiresIn ?? '1h' });
   return token;
 };
 
 export const generateVerificationToken = (email: string): string => {
-  const secret = process.env.JWT_SECRET;
-
-  if (!secret) {
-    throw new Error('JWT_SECRET is not defined in environment variables.');
-  }
-
   const payload = { email };
   const token = jwt.sign(payload, secret, { expiresIn: '1h' });
   return token;
 };
 
 export const verifyToken = (token: string): any | null => {
-  const secret = process.env.JWT_SECRET;
-
-  if (!secret) {
-    throw new Error('JWT_SECRET is not defined in environment variables.');
-  }
-
   const res = verifyTokenDetailed(token);
   return res.ok ? res.payload : null;
 };
@@ -48,10 +33,6 @@ export type VerifyTokenResult =
   | { ok: false; reason: 'expired' | 'invalid' };
 
 export const verifyTokenDetailed = (token: string): VerifyTokenResult => {
-  const secret = process.env.JWT_SECRET;
-  if (!secret) {
-    throw new Error('JWT_SECRET is not defined in environment variables.');
-  }
   try {
     const decoded = jwt.verify(token, secret);
     return { ok: true, payload: decoded };

--- a/src/lib/aws/dynamodb.ts
+++ b/src/lib/aws/dynamodb.ts
@@ -1,18 +1,19 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { config } from '@/lib/config';
 
 // .env.local 파일의 DYNAMODB_ENDPOINT 값을 사용하도록 변경
-const endpoint = process.env.DYNAMODB_ENDPOINT;
+const endpoint = config.dynamodbEndpoint;
 
 // log endpoint for debugging
 console.log('DynamoDB Endpoint:', endpoint);
 
 const client = new DynamoDBClient({
-  region: process.env.AWS_REGION || 'ap-northeast-2',
+  region: config.awsRegion,
   endpoint: endpoint,
   credentials: {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'dummy',
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'dummy',
+    accessKeyId: config.awsAccessKeyId || 'dummy',
+    secretAccessKey: config.awsSecretAccessKey || 'dummy',
   },
 });
 

--- a/src/lib/aws/s3.ts
+++ b/src/lib/aws/s3.ts
@@ -1,19 +1,20 @@
 import { S3Client, S3ClientConfig } from '@aws-sdk/client-s3';
+import { config } from '@/lib/config';
 
-const isDevelopment = process.env.NODE_ENV === 'development';
+const isDevelopment = config.nodeEnv === 'development';
 
 const s3Config: S3ClientConfig = {
-  region: process.env.AWS_REGION || 'ap-northeast-2',
+  region: config.awsRegion,
   credentials: {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'dummy',
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'dummy',
+    accessKeyId: config.awsAccessKeyId || 'dummy',
+    secretAccessKey: config.awsSecretAccessKey || 'dummy',
   },
 };
 
 if (isDevelopment) {
   // Prefer explicit endpoint if provided (e.g., set in docker-compose for container networking)
-  s3Config.endpoint = process.env.S3_ENDPOINT || 'http://localstack:4566';
-  s3Config.region = process.env.AWS_REGION || 'ap-northeast-2';
+  s3Config.endpoint = config.s3Endpoint || 'http://localstack:4566';
+  s3Config.region = config.awsRegion;
   s3Config.forcePathStyle = true;
 }
 

--- a/src/lib/aws/sqs.ts
+++ b/src/lib/aws/sqs.ts
@@ -1,15 +1,16 @@
 import { SQSClient } from '@aws-sdk/client-sqs';
+import { config } from '@/lib/config';
 
-const isDev = process.env.NODE_ENV === 'development';
+const isDev = config.nodeEnv === 'development';
 
 export const sqsClient = new SQSClient({
-  region: process.env.AWS_REGION || 'ap-northeast-2',
-  endpoint: isDev ? (process.env.SQS_ENDPOINT || undefined) : undefined,
+  region: config.awsRegion,
+  endpoint: isDev ? config.sqsEndpoint : undefined,
   // In development allow dummy creds (LocalStack); in production rely on default provider chain
   credentials: isDev
     ? {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'dummy',
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'dummy',
+        accessKeyId: config.awsAccessKeyId || 'dummy',
+        secretAccessKey: config.awsSecretAccessKey || 'dummy',
       }
     : undefined,
 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,23 @@
+const required = (key: string): string => {
+  const value = process.env[key];
+  if (!value) throw new Error(`Missing environment variable: ${key}`);
+  return value;
+};
+
+export const config = {
+  jwtSecret: required('JWT_SECRET'),
+  geminiApiKey: required('GEMINI_API_KEY'),
+  s3BucketName: required('S3_BUCKET_NAME'),
+  awsRegion: process.env.AWS_REGION || 'ap-northeast-2',
+  awsAccessKeyId: process.env.AWS_ACCESS_KEY_ID,
+  awsSecretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  s3PublicEndpoint: process.env.S3_PUBLIC_ENDPOINT,
+  s3Endpoint: process.env.S3_ENDPOINT,
+  sqsEndpoint: process.env.SQS_ENDPOINT,
+  dynamodbEndpoint: process.env.DYNAMODB_ENDPOINT,
+  summarizeSqsQueueUrl: process.env.SUMMARIZE_SQS_QUEUE_URL,
+  hashSalt: process.env.HASH_SALT,
+  nodeEnv: process.env.NODE_ENV,
+} as const;
+
+export type AppConfig = typeof config;

--- a/src/lib/documents/queue.ts
+++ b/src/lib/documents/queue.ts
@@ -1,8 +1,9 @@
 import { SendMessageCommand } from '@aws-sdk/client-sqs';
 import { sqsClient } from '@/lib/aws/sqs';
+import { config } from '@/lib/config';
 
 export async function enqueueSummarizeJob(userId: string, documentId: string) {
-  const queueUrl = process.env.SUMMARIZE_SQS_QUEUE_URL;
+  const queueUrl = config.summarizeSqsQueueUrl;
   if (!queueUrl) throw new Error('SUMMARIZE_SQS_QUEUE_URL is not configured');
   const message = {
     type: 'DOCUMENT_SUMMARIZE',


### PR DESCRIPTION
## Summary
- centralize environment variable validation in `config.ts`
- refactor auth, API routes, and AWS clients to consume injected config

## Testing
- `pnpm lint` *(fails: Unexpected any warnings across repo)*
- `pnpm test:auth`


------
https://chatgpt.com/codex/tasks/task_e_68bfcbaeac84832c9320a00a46603fbc