### PR TITLE
docs: add iac standard guidelines

### DIFF
--- a/docs/architecture/current-to-todo-transition-plan.md
+++ b/docs/architecture/current-to-todo-transition-plan.md
@@ -1,0 +1,81 @@
+# 현행 시스템 → 목표 아키텍처 전환 작업 계획서
+
+## 1. 배경 및 목표
+- **배경**: `docs/architecture/current-system.md`에서 정의된 Next.js 모놀리식 구조는 동기식 Gemini 요약, .env 기반 비밀 관리 등 여러 제약을 갖고 있다.
+- **목표**: `docs/architecture/todo-system.md`에 정의된 AWS 서버리스 기반 구조로 이전하여 자동화된 배포, 비동기 요약 처리, Secrets Manager 연동을 달성한다.
+
+## 2. 전환 범위
+1. 애플리케이션 계층을 Lambda/API Gateway 기반으로 재구성한다.
+2. 비동기 요약 워크플로(SQS + `services/ai-processor`)를 활성화한다.
+3. UI 정적 배포 파이프라인을 S3/CloudFront로 분리한다.
+4. CloudFormation(또는 CDK) 스택을 작성하여 인프라를 코드화한다.
+5. GitHub Actions CI/CD 파이프라인을 구축하여 브랜치별 자동 배포를 구성한다.
+
+## 3. 추진 전략 및 단계
+### 단계 1. 설계 정교화 및 준비 (1~2주)
+- `application-architecture-notes.md`의 제약 사항 및 리스크를 기반으로 세부 요구사항을 확정한다.
+  - SLA 요구사항(요약 20초), 허용 파일 형식(.txt/.md/.pdf/.docs), 비밀 관리 전환 등 미스매치 항목을 정리하여 이해관계자 승인한다.
+  - DynamoDB 정렬키 패턴을 `PROFILE#<userId>`로 확정하고, 기존 문서(`PROFILE`)와의 차이를 보정하기 위한 마이그레이션 및 스키마 업데이트 계획을 작성한다.
+  - 요약 엔진 전략(초기 Gemini 고정, 후속 엔진 추가 대비)을 합의하고 Secrets Manager 키 네이밍/버저닝·교차 엔진 구성 정책을 정의한다.
+  - 비동기 요약 활성화(`SUMMARIZE_ASYNC=true`) 시 예상되는 SQS 큐 크기, Lambda 동시 실행 한계, 재시도·DLQ 정책을 산정하여 요구되는 모니터링 항목을 목록화한다.
+  - IaC 접근 방식(CloudFormation 템플릿 vs CDK)과 공통 태깅, IAM 최소 권한 표준을 문서화해 후속 단계의 구현 가이드로 배포한다.
+    - 결과물: [`docs/architecture/iac-guidelines.md`](./iac-guidelines.md) 및 요약본 [`docs/done/step-01-iac-guideline-summary.md`](../done/step-01-iac-guideline-summary.md).
+- 의사결정 결과를 `docs/architecture/todo-system.md` 및 부속 설계 문서에 반영하기 위한 업데이트 백로그와 승인 절차를 수립한다.
+
+### 단계 2. 공통 모듈 정비 (1주)
+- `packages/@echo-ai/*` 모듈을 Lambda 번들링에 적합하도록 의존성 및 환경 변수 로딩 로직 점검.
+- `SUMMARIZE_ASYNC` 기본값을 true로 전환하기 위한 설정 및 테스트 계획 수립.
+- 로컬 개발 환경(Docker Compose)에서 Lambda 시뮬레이션 전략 정의.
+
+### 단계 3. 백엔드 기능 분리 (2~3주)
+- `services/api`에 인증, 문서 CRUD, 요약 트리거 Lambda 핸들러 구현.
+- API Gateway 라우팅 규칙과 요청/응답 스키마 정의.
+- `services/ai-processor` Lambda가 SQS 메시지를 처리하여 DynamoDB/S3와 상호작용하도록 구현.
+- 30초 SLA 충족을 위한 병렬 처리·타임아웃 설정 적용.
+
+### 단계 4. 인프라 코드 작성 (2주)
+- `infra/` 디렉터리에 `echoai-shared`, `echoai-api`, (선택) `echoai-ops` 스택 템플릿 작성.
+- IAM 역할 최소 권한, 태깅 정책, CloudWatch 로그/알람 구성을 포함.
+- 로컬/스테이징/프로덕션 환경 파라미터 정의 및 문서화.
+
+### 단계 5. CI/CD 파이프라인 구축 (1~2주)
+- GitHub Actions 워크플로 추가: Lint/Test → Build → 배포 패키징.
+- OIDC 기반 IAM Role 연동 및 비밀 접근 권한 설정.
+- 변경 감지 로직 구현: UI 전용 변경 시 S3 업로드 + CloudFront 무효화, 백엔드 변경 시 CloudFormation 배포.
+- Secrets Manager 업데이트 자동화 및 실패 알림 채널 구성.
+
+### 단계 6. 전환 및 검증 (2주)
+- 스테이징 환경에서 종단 간 통합 테스트(인증, 업로드, 요약, 조회) 수행.
+- 성능 검증: 요약 처리 시간, Lambda 동시 실행 한계, SQS 적체 모니터링.
+- 보안 검토: IAM 정책, Secrets Manager 접근 제어, 네트워크 구성.
+- 운영 환경 전환 계획 수립(릴리즈 창구, 롤백 전략, 장애 대응 절차).
+
+## 4. 산출물
+- 업데이트된 시스템 문서: `docs/architecture/todo-system.md` 반영 + 전환 결정 사항.
+- Lambda/API 코드 (`services/api`, `services/ai-processor`), 패키지 조정 내역.
+- CloudFormation/CDK 템플릿 (`infra/**`).
+- GitHub Actions 워크플로 정의 (`.github/workflows/**`).
+- 테스트/검증 보고서 및 운영 절차 문서.
+
+## 5. 리스크 및 대응
+| 리스크 | 영향 | 대응 전략 |
+| --- | --- | --- |
+| Lambda 실행 환경과 Next.js 의존성 차이 | 번들 실패, 런타임 오류 | 모듈별 번들 크기/호환성 사전 검토, Lambda Layer 활용 |
+| Gemini ↔ OpenAI 전환 결정 지연 | Secrets 구조 변경, 코드 재작업 | 추상화 레이어 설계, 두 엔진을 선택적으로 호출 가능하도록 인터페이스 정의 |
+| CI/CD 파이프라인 복잡도 증가 | 배포 실패, 롤백 지연 | 단계별 파이프라인 구축, 스테이징에서 충분한 연습, IaC 변경 시 Change Set 활용 |
+| DynamoDB 스키마 불일치 | 데이터 마이그레이션 실패 | 단계 1에서 스키마 확정, 마이그레이션 스크립트/백업 전략 수립 |
+
+## 6. 일정 및 역할 제안
+| 역할 | 주요 책임 | 예상 투입 |
+| --- | --- | --- |
+| 아키텍트/리드 | 설계 확정, 인프라 코드 표준, 일정 관리 | 전체 기간 |
+| 백엔드 개발자 | Lambda 구현, 패키지 정비, DynamoDB/SQS 연동 | 단계 2~6 |
+| 프런트엔드 개발자 | UI 정적 빌드 최적화, CloudFront 배포 검증 | 단계 3~6 |
+| DevOps 엔지니어 | CI/CD, Secrets/IAM 설정, 모니터링 구축 | 단계 4~6 |
+
+## 7. 완료 기준
+- `todo-system.md`에 정의된 토폴로지 요소가 프로덕션 환경에서 운영 중이다.
+- 비동기 요약 Lambda가 20초 SLA 내에서 동작하며, CloudWatch 지표가 설정되었다.
+- GitHub Actions가 브랜치 머지 시 자동으로 적절한 배포 Job을 수행한다.
+- Secrets Manager가 모든 민감 정보를 관리하며 `.env` 의존이 제거되었다.
+- 운영·장애 대응 문서가 최신 상태로 업데이트되었다.

--- a/docs/architecture/iac-guidelines.md
+++ b/docs/architecture/iac-guidelines.md
@@ -1,0 +1,107 @@
+# IaC 구현 가이드 (CloudFormation vs AWS CDK)
+
+본 가이드는 `docs/architecture/current-to-todo-transition-plan.md` 1단계 과제 중 하나인 "IaC 접근 방식(CloudFormation 템플릿 vs CDK)과 공통 태깅, IAM 최소 권한 표준" 확립을 위해 작성되었다. AWS CDK를 1차 표준으로 채택하되, 순수 CloudFormation 템플릿이 필요한 예외 상황도 지원하도록 한다.
+
+## 1. 의사결정 요약
+- **주 표준**: AWS CDK(TypeScript).
+  - 기존 코드베이스가 TypeScript 모노레포로 구성되어 있어 동일 언어 기반의 IaC가 온보딩 비용을 낮춘다.
+  - 고수준 Construct를 활용해 반복 리소스 정의를 줄이고, 스택 간 공유 패턴(예: 태그, IAM 정책)을 코드로 재사용할 수 있다.
+  - `cdk.json`/`context`를 활용한 환경 파라미터 관리가 용이하며, GitHub Actions에서 `pnpm` 기반 워크플로우와 자연스럽게 통합된다.
+- **보조 표준**: CloudFormation 템플릿.
+  - 보안·규제상 Change Set 리뷰가 필요한 리소스나, AWS 서비스 팀에서 제공하는 샘플 템플릿을 그대로 사용해야 하는 경우 보조 수단으로 유지한다.
+  - CDK `Cfn*` Construct 또는 `cdk synth --no-staging`으로 추출한 템플릿을 소스 관리하여 이중화한다.
+
+## 2. CloudFormation vs CDK 비교
+| 항목 | AWS CDK | 순수 CloudFormation |
+| --- | --- | --- |
+| 언어 | TypeScript(공통 언어 재사용) | YAML/JSON(별도 문법) |
+| 재사용성 | Construct, 스택 조합 가능 | 템플릿 조각 재활용 어려움 |
+| 변경 추적 | 코드 diff로 의도 파악 용이 | 리소스 변경 시 diff 가독성 낮음 |
+| 운영 절차 | `cdk diff/deploy`, Pipeline 구성 쉬움 | Change Set + Manual deploy |
+| 러닝 커브 | 기존 TS 개발자에게 친숙 | 인프라/DevOps 팀에는 익숙 |
+| 예외 처리 | L1/L2 Construct로 대부분 커버 | 모든 리소스를 원시 수준에서 제어 |
+
+**결론**: 전사 표준은 CDK로 통일하되, 사전 승인된 예외에 한해 CloudFormation 템플릿을 저장소(`infra/cloudformation`)에 병행 보관한다.
+
+## 3. 디렉터리 및 브랜치 전략
+- `infra/cdk/` 내 스택 구성
+  - `infra/cdk/bin/echoai.ts`: 엔트리 포인트, `SharedStack`, `ApiStack`, `OpsStack` 등 환경별 인스턴스를 생성.
+  - `infra/cdk/lib/`: 각 스택 정의. 공통 Construct는 `lib/shared/`에 배치.
+  - `infra/cdk/context/dev.json`, `stage.json`, `prod.json`: 환경별 파라미터(도메인, 용량, 엔드포인트 URL 등)를 JSON으로 분리.
+- CloudFormation 예외 템플릿은 `infra/cloudformation/<service>/<stack>.yaml` 구조로 보관하고, README에 사용 용도를 명시한다.
+- 브랜치 전략은 기존 모노레포와 동일하게 `main`/`develop` 기준을 유지하며, IaC 변경은 Pull Request 설명에 `cdk diff` 결과 요약을 첨부한다.
+
+## 4. 공통 태깅 표준
+모든 스택/리소스는 CDK `Tags.of(resource).add(key, value)` 또는 CloudFormation `Tags` 항목을 통해 다음 태그를 필수 부여한다.
+
+| Key | Value 규칙 | 비고 |
+| --- | --- | --- |
+| `Project` | `echo-ai` | 전체 공통 |
+| `Environment` | `dev`/`stage`/`prod` | context 파라미터에서 주입 |
+| `Owner` | `platform@echo-ai.internal` | 운영 책임자 메일 |
+| `CostCenter` | `ml-ops` | 재무 보고용 |
+| `Confidentiality` | `internal`/`restricted` | 데이터 민감도에 따라 선택 |
+
+- 추가 태그가 필요한 경우 `infra/cdk/lib/tags.ts`에 헬퍼 함수를 두고 일괄 관리한다.
+- CloudFormation 예외 템플릿에도 동일 태그를 하드코딩하거나 Parameter + Mapping 조합으로 적용한다.
+
+## 5. IAM 최소 권한 정책 표준
+### 5.1 원칙
+1. **권한 분리**: 스택별 IAM Role은 리소스 목적(예: API Lambda, Summarizer Lambda, 배포 파이프라인) 기준으로 분리한다.
+2. **Least Privilege**: `actions`, `resources`, `conditions`를 모두 명시하고 `*` 사용을 피한다.
+3. **정기 감사**: CDK `iam.AccessAnalyzer` 리포트를 CI에서 실행하여 과도한 권한을 감지한다.
+
+### 5.2 역할별 가이드
+- **API Lambda Role (`EchoApiLambdaRole`)**
+  - 허용 작업: `dynamodb:GetItem`, `dynamodb:Query`, `sqs:SendMessage`, `logs:CreateLogStream/PutLogEvents`.
+  - 리소스 범위: 테이블/큐 ARN을 `Fn.importValue` 또는 CDK `Table.fromTableArn`으로 주입해 특정 ARN으로 제한.
+  - 조건: 필요 시 `"dynamodb:LeadingKeys": ["USER#"]` 등 프리픽스 조건을 추가.
+- **Summarizer Lambda Role (`EchoSummarizerRole`)**
+  - 허용 작업: `dynamodb:UpdateItem`, `s3:PutObject`, `secretsmanager:GetSecretValue`, `logs:*` 최소 범위.
+  - Secrets 접근은 `Secret.fromSecretNameV2`로 특정 시크릿만 허용.
+- **GitHub Actions OIDC Role (`EchoPipelineRole`)**
+  - 신뢰 정책: GitHub OIDC Provider + 리포지토리 조건.
+  - 작업: `cloudformation:*ChangeSet*`, `cloudformation:Describe*`, `iam:PassRole`(대상 스택 롤만), `lambda:UpdateFunctionCode`, `s3:PutObject`(배포 아티팩트 버킷).
+- **Operations Role (`EchoOpsRole`)**
+  - 비상 조치를 위해 `cloudwatch:PutMetricAlarm`, `lambda:UpdateEventSourceMapping` 등 제한적 운영 권한.
+
+### 5.3 CDK 구현 예시
+```ts
+import { Duration, Tags } from 'aws-cdk-lib';
+import { Table } from 'aws-cdk-lib/aws-dynamodb';
+import { Function, Runtime, Code } from 'aws-cdk-lib/aws-lambda';
+import { Role, ServicePrincipal, PolicyStatement, Effect } from 'aws-cdk-lib/aws-iam';
+
+const table = Table.fromTableArn(this, 'ProfilesTable', props.profilesTableArn);
+const queue = Queue.fromQueueArn(this, 'SummaryQueue', props.summaryQueueArn);
+
+const apiRole = new Role(this, 'EchoApiLambdaRole', {
+  assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
+});
+
+apiRole.addToPolicy(new PolicyStatement({
+  effect: Effect.ALLOW,
+  actions: ['dynamodb:GetItem', 'dynamodb:Query'],
+  resources: [table.tableArn],
+}));
+
+apiRole.addToPolicy(new PolicyStatement({
+  effect: Effect.ALLOW,
+  actions: ['sqs:SendMessage'],
+  resources: [queue.queueArn],
+}));
+```
+
+- CloudFormation 예외 시 동일 정책을 YAML로 변환해 별도 템플릿에 반영한다.
+- Lambda 로그 권한은 `aws-cdk-lib/aws-logs` 모듈의 `LogGroup.grantWrite`를 사용해 붙인다.
+
+## 6. CDK 배포 절차 및 품질 관리
+1. `pnpm install` 후 `pnpm --filter infra-cdk build`(별도 패키지 구성 시) → `cdk synth`로 템플릿 확인.
+2. PR 작성 전 `cdk diff --context env=dev` 출력 요약을 PR 본문에 첨부.
+3. main 병합 후 GitHub Actions가 `cdk deploy --require-approval=never`를 실행.
+4. 배포 실패 시 Change Set을 검토하고, 필요한 경우 `cdk deploy --app 'npx ts-node bin/echoai.ts' --profile <ops>` 방식으로 수동 복구.
+
+## 7. 후속 조치
+- 본 가이드 요약본을 `docs/done/step-01-iac-guideline-summary.md`로 배포해 이해관계자에 공유한다.
+- `docs/architecture/todo-system.md` 내 IaC 섹션을 본 표준에 맞게 업데이트할 백로그를 등록한다.
+- IAM 템플릿 검증을 위해 Step Functions 기반 권한 감사 워크플로 도입 여부를 평가한다.

--- a/docs/architecture/step-01-prep-decisions.md
+++ b/docs/architecture/step-01-prep-decisions.md
@@ -1,0 +1,33 @@
+# 단계 1 설계 정교화 의사결정 요약
+
+본 문서는 `application-architecture-notes.md`에서 파생된 미확정 항목을 1단계 준비 구간에서 확정하기 위한 결정 사항을 정리한다. 이해관계자 검토자는 제품 오너(요청자)로, 본 문서 내 결정은 즉시 승인된 것으로 간주한다.
+
+## 1. 서비스 수준 및 파일 정책
+- **요약 SLA**: 비동기 요약 파이프라인(업로드 → SQS → Lambda → Gemini)은 작업당 _최대 20초_ 내 응답(요약 생성)을 목표로 한다. Lambda 타임아웃은 25초로 설정하고, CloudWatch 알람은 18초 초과 비율(5분 윈도) 5% 이상 시 경보를 발송한다.
+- **허용 파일 형식**: `.txt`, `.md`, `.pdf`, `.docs` 4종을 1차 허용 확장자로 고정한다. MIME 검증 로직을 강화하고, 추후 확장 시 문서화·테스트를 병행한다.
+
+## 2. 비밀 관리 및 구동 환경
+- **전환 방향**: `.env` 파일 사용을 중단하고 AWS Secrets Manager를 단일 사실 원천(Single Source of Truth)으로 지정한다.
+- **정책**:
+  - 시크릿 이름 규칙은 `echoai/{stage}/{purpose}` 패턴을 사용한다. 예) `echoai/prod/gemini/api-key`.
+  - 키 버저닝을 활성화하고, 변경 시 GitHub Actions 배포 파이프라인에서 최신 버전을 자동 주입한다.
+  - Gemini, 향후 추가 AI 엔진(OpenAI 등), 데이터베이스 자격 증명, 서드파티 통합 토큰을 모두 포함한다.
+
+## 3. DynamoDB 정렬키 결정
+- **조사 내용**: 현재 Next.js API 라우트는 사용자 프로필을 `PK=USER#<userId>`, `SK=PROFILE#<userId>` 패턴으로 조회한다. `docs/architecture/current-system.md` 등 기존 문서에는 `SK=PROFILE`로만 표기되어 있어 정합성 차이가 존재한다.
+- **결정**: 다중 프로필 시나리오 대비와 명시적인 사용자 식별을 위해 `PROFILE#<userId>` 패턴을 유지한다. 이 패턴은 기존 코드와 일치하며(`apps/web/src/app/api/me/route.ts`, `apps/web/src/app/api/auth/signup/route.ts`), 향후 `SK=PROFILE#<userId>#<suffix>` 확장도 용이하다.
+- **후속 조치**: `docs/architecture/current-system.md` 및 `docs/architecture/todo-system.md`의 스키마 섹션을 업데이트하고, 마이그레이션 스크립트에서는 `PROFILE` 패턴 데이터를 `PROFILE#<userId>`로 변환한다.
+
+## 4. 요약 엔진 로드맵
+- **초기 배포**: Gemini Flash 모델을 기본 엔진으로 고정한다.
+- **확장 전략**: 요약 서비스 계층에 엔진 추상화 인터페이스를 도입하여 OpenAI 등 추가 엔진을 구성 플래그로 주입할 수 있도록 한다. Secrets Manager에는 엔진별 API 키를 병렬 저장한다.
+- **검증**: 스테이징 환경에서 Gemini 20초 SLA 충족 여부를 검증하고, 추후 엔진 추가 시 회귀 테스트를 자동화한다.
+
+## 5. 모니터링 및 운영 준비
+- **SQS 및 Lambda 용량 계획**:
+  - SQS 기본 큐 길이 임계치: 200 메시지 이상 시 경보.
+  - Lambda 동시 실행 예약: 25개(선형 확장 가능), 최대 재시도 횟수 2회, DLQ는 별도 큐(`echoai-summarize-dlq`)로 지정한다.
+- **관찰성**: CloudWatch 대시보드에 요약 처리 시간 p95, Lambda 에러율, DLQ 적재량을 표시하고, 로그에는 추적 ID와 엔진 정보를 포함한다.
+
+## 6. 승인
+- 모든 항목은 제품 오너(요청자)의 지시에 따라 즉시 승인 처리한다. 추가 변경이 필요한 경우 본 문서를 개정한다.

--- a/docs/done/step-01-iac-guideline-summary.md
+++ b/docs/done/step-01-iac-guideline-summary.md
@@ -1,0 +1,20 @@
+# 단계 1 산출물: IaC 구현 가이드 배포 내역
+
+본 메모는 "IaC 접근 방식(CloudFormation 템플릿 vs CDK)과 공통 태깅, IAM 최소 권한 표준" 문서화 작업의 완료 내역을 기록한다. 이해관계자(요청자)는 본 요약을 확인 즉시 승인된 것으로 간주한다.
+
+## 1. 산출물 개요
+- **주요 문서**: [`docs/architecture/iac-guidelines.md`](../architecture/iac-guidelines.md)
+- **주요 내용**:
+  - AWS CDK(TypeScript)를 1차 표준으로 채택하고, 제한된 범위 내에서 CloudFormation 템플릿을 병행 지원하는 결정.
+  - 스택 디렉터리 구조, 환경별 context 관리, Pull Request 시 `cdk diff` 공유 등 운영 절차 정의.
+  - 모든 리소스에 적용할 공통 태깅 규칙(Project, Environment, Owner, CostCenter, Confidentiality).
+  - Lambda, 배포 파이프라인, 운영 롤에 대한 IAM 최소 권한 가이드와 CDK 코드 예시.
+  - 배포 품질 관리를 위한 `cdk synth/diff/deploy` 수행 절차.
+
+## 2. 적용 및 후속 과제
+- 4단계 인프라 코드 작성 시 본 가이드를 기반으로 스택을 구현한다.
+- CloudFormation 예외가 필요한 경우 `infra/cloudformation` 경로에 템플릿과 승인 사유를 명시한다.
+- IAM 권한 검증 자동화를 위해 Access Analyzer 또는 커스텀 감사 파이프라인 도입을 검토한다.
+
+## 3. 승인
+- 본 요약과 상세 가이드는 제품 오너(요청자) 확인 즉시 효력이 발생한다. 추가 변경 사항이 있으면 문서를 개정한다.


### PR DESCRIPTION
## Summary
- document the preferred AWS CDK-first IaC standard with CloudFormation exceptions, tagging requirements, and least-privilege IAM patterns
- publish a step-01 delivery note summarizing the IaC guideline deliverable and link it from the transition plan

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d4dfcb9fbc832ca9486fdca8482204